### PR TITLE
Fixing Passhash login

### DIFF
--- a/jasonlashua-prtg-datasource/src/PRTGAPIService.js
+++ b/jasonlashua-prtg-datasource/src/PRTGAPIService.js
@@ -218,7 +218,7 @@ function PRTGAPIService(alertSrv, backendSrv) {
           passhash
       };
       return this.backendSrv.datasourceRequest(options).then(response => {
-        this.passhash = response;
+        //this.passhash = response;
         return response;
       });
     }


### PR DESCRIPTION
Commenting out setting passhash to the response of the backend server.  The response is an object vs the actual passhash.  The plugin collects passhash already so there should be no need to reset the value.